### PR TITLE
Created apollo-federation.mdx

### DIFF
--- a/website/docs/advanced/apollo-federation.mdx
+++ b/website/docs/advanced/apollo-federation.mdx
@@ -1,0 +1,29 @@
+---
+title: Apollo Federation
+---
+
+# Apollo Federation Integration
+
+If you are using graphql-shield with an Apollo Federation gateway, you may need to whitelist a few properties to avoid authentication errors during initial introspection & composition
+
+## Example
+
+```ts
+const permissions = shield(
+  {
+    Query: {
+      _service: allow,
+    },
+    _Service: {
+      sdl: allow,
+    },
+  },
+  {
+    fallbackRule: deny,
+  },
+)
+```
+
+Other properties which might need to be whitelisted include: "Query._entities", "Query._service", "_Entity.\*", "_Service.\*", "_Any.\*"
+
+Note: Consider implementing more rigid security rather than using "allow"

--- a/website/routes.ts
+++ b/website/routes.ts
@@ -9,7 +9,7 @@ export function getRoutes(): IRoutes {
         _: {
           advanced: {
             $name: 'Advanced',
-            $routes: ['whitelisting', 'reference', 'troubleshooting', 'reference'],
+            $routes: ['whitelisting', 'reference', 'troubleshooting', 'reference', 'apollo-federation'],
           },
         },
       },


### PR DESCRIPTION
I struggled using Graphql-shield with an Apollo Federation gateway. Due to my fallbackRule being set to deny, the endpoints required by Apollo Federation were blocked. Couldn't find any documentation for this issue, but I found a few unanswered questions on Stack Overflow. I would have appreciated seeing something like this earlier, so wrote this to help others with this common(?) problem