### PR TITLE
uuid 8.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4875,7 +4875,7 @@ __metadata:
     stream.pipeline-shim: ^1.1.0
     strip-ansi: ^5.2.0
     traverse: ^0.6.6
-    uuid: ^3.4.0
+    uuid: ^8.3.2
     ws: ^7.3.1
   bin:
     components: bin/bin
@@ -4924,7 +4924,7 @@ __metadata:
     semver: ^6.3.0
     simple-git: ^1.132.0
     source-map-support: ^0.5.19
-    uuid: ^3.4.0
+    uuid: ^8.3.2
     yamljs: ^0.3.0
   checksum: b5e349d6cb603951bba83120b3bded6c1715ba7791bdda459f277db850bcd2d7d246f27fefd658f5111e7e73a69a21423cfb8cd2e2de2016f4829aee2e2dd79c
   languageName: node
@@ -5005,7 +5005,7 @@ __metadata:
     rc: ^1.2.8
     regenerator-runtime: ^0.13.7
     source-map-support: ^0.5.19
-    uuid: ^3.4.0
+    uuid: ^8.3.2
     write-file-atomic: ^2.4.3
     ws: <7.0.0
   checksum: c25bdfbb17e68d2324087f5b484c648018e6170f2581ecdbfe3ded33dce9b0f0484ccbafdf6cb28825b0cd900ce7fa43306a40fce2de9337e4a10e891019e945
@@ -5051,7 +5051,7 @@ __metadata:
     lodash: ^4.17.15
     rc: ^1.2.8
     type: ^2.0.0
-    uuid: ^3.4.0
+    uuid: ^8.3.2
     write-file-atomic: ^2.4.3
   checksum: 1161b584901e3326a4b84230ac2f891a4460d8d25ae89f7e0bd65f9c5d23dd0d9edc0b4e2c5b97f52d6dc4aea569cccf2b99f9b9dbbdda6d22af83299878faf2
   languageName: node
@@ -6767,7 +6767,7 @@ __metadata:
     lru-cache: ^6.0.0
     sha.js: ^2.4.11
     subscriptions-transport-ws: ^0.9.19
-    uuid: ^8.0.0
+    uuid: ^8.3.2
   peerDependencies:
     graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
   checksum: 9470fd40eb084e3b62f891b5776238e6a9476253bb3626f9fc8eb60f384babc56d48b6109f0059dcc79253350fe43b45617b6a13ca0ea7c7261ec7b51469713f
@@ -6798,7 +6798,7 @@ __metadata:
     loglevel: ^1.6.8
     lru-cache: ^6.0.0
     sha.js: ^2.4.11
-    uuid: ^8.0.0
+    uuid: ^8.3.2
     whatwg-mimetype: ^3.0.0
   peerDependencies:
     graphql: ^15.3.0 || ^16.0.0
@@ -7504,7 +7504,7 @@ __metadata:
     querystring: 0.2.0
     sax: 1.2.1
     url: 0.10.3
-    uuid: 3.3.2
+    uuid: 8.3.2
     xml2js: 0.4.19
   checksum: 39862bf22704fff74299a2bbf92ae5fdb0c4f7749909117910b2330413c3a845f1b90cde8cc366e04551f8186fad0805c835fdefef0660eed83375f547768e72
   languageName: node
@@ -14307,7 +14307,7 @@ fsevents@^1.2.7:
     apollo-utilities: ^1.0.1
     deprecated-decorator: ^0.1.6
     iterall: ^1.1.3
-    uuid: ^3.1.0
+    uuid: ^8.3.2
   peerDependencies:
     graphql: ^0.13.0 || ^14.0.0
   checksum: eec1495ac1cf9422bd1a9448d7a34e76264fe81c30b2fbc465131b66257923ced24f6259600b2c69b5952b3203b8d58927e001f3ef91bba02e29ce120183e612
@@ -14322,7 +14322,7 @@ fsevents@^1.2.7:
     apollo-utilities: ^1.0.1
     deprecated-decorator: ^0.1.6
     iterall: ^1.1.3
-    uuid: ^3.1.0
+    uuid: ^8.3.2
   peerDependencies:
     graphql: ^0.13.0 || ^14.0.0 || ^15.0.0
   checksum: 6a2dc7f158a87444943db0762dafdbcc6dbfd57a398c6615721a6c1a150641d76f5efca2109685aadb0c1df6ba8ff5bd0fdddcb690c36d3d4f608b46e40427a7
@@ -22308,7 +22308,7 @@ fsevents@^1.2.7:
     md5: ^2.2.1
     stack-trace: 0.0.10
     timed-out: 4.0.1
-    uuid: 3.3.2
+    uuid: 8.3.2
   bin:
     raven: ./bin/raven
   checksum: 55a266e7436463256097760db73040028ef1018f3baae2bd5ac444371f6c8b3748f813fa951a5012da91d0d75164f3d66fe4f575dda89505bc1f4eff4c542cbb
@@ -23259,7 +23259,7 @@ fsevents@^1.2.7:
     safe-buffer: ^5.1.2
     tough-cookie: ~2.5.0
     tunnel-agent: ^0.6.0
-    uuid: ^3.3.2
+    uuid: ^8.3.2
   checksum: 4e112c087f6eabe7327869da2417e9d28fcd0910419edd2eb17b6acfc4bfa1dad61954525949c228705805882d8a98a86a0ea12d7f739c01ee92af7062996983
   languageName: node
   linkType: hard
@@ -23918,7 +23918,7 @@ fsevents@^1.2.7:
     timers-ext: ^0.1.7
     type: ^2.5.0
     untildify: ^3.0.3
-    uuid: ^3.4.0
+    uuid: ^8.3.2
     write-file-atomic: ^2.4.3
     yaml-ast-parser: 0.0.43
     yargs-parser: ^18.1.3
@@ -25554,7 +25554,7 @@ fsevents@^1.2.7:
     https-proxy-agent: ^5.0.0
     node-fetch: ^2.6.1
     stream-events: ^1.0.5
-    uuid: ^8.0.0
+    uuid: ^8.3.2
   checksum: 3ac6ade7d5ea8c96b6a71c8f7b75dd3f0a939b8c25e9c4ef87edf021264ef07417f2df4ca22f0ff72b3fdccb2616a92cdf2008e0819188e79390a3e79b426a46
   languageName: node
   linkType: hard
@@ -25581,7 +25581,7 @@ fsevents@^1.2.7:
     is-stream: ^2.0.0
     make-dir: ^3.0.0
     temp-dir: ^1.0.0
-    uuid: ^3.3.2
+    uuid: ^8.3.2
   checksum: 4f94187662968b7cc9d88d7f8eeecc9e7317e26d640d2f90e833151e1049702ec6c63512d095b8bd69c09735eb5b5bfba9bb37dbed3bf2fe8b01076ffa161338
   languageName: node
   linkType: hard
@@ -27220,30 +27220,30 @@ typescript@4.3.5:
   languageName: node
   linkType: hard
 
-"uuid@npm:3.3.2":
-  version: 3.3.2
-  resolution: "uuid@npm:3.3.2"
+"uuid@npm:8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
   bin:
     uuid: ./bin/uuid
-  checksum: 8793629d2799f500aeea9fcd0aec6c4e9fbcc4d62ed42159ad96be345c3fffac1bbf61a23e18e2782600884fee05e6d4012ce4b70d0037c8e987533ae6a77870
+  checksum: aed2bcef341f95635f308fea8831fb9038b18c485fe7e71feb89d2e05602dfecad0cb6f2246fae096d4da425cca6e8a71056f28abd97ad98cf770a2018853248
   languageName: node
   linkType: hard
 
-"uuid@npm:^3.1.0, uuid@npm:^3.3.2, uuid@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "uuid@npm:3.4.0"
+"uuid@npm:^8.3.2:
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
   bin:
     uuid: ./bin/uuid
-  checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
+  checksum: aed2bcef341f95635f308fea8831fb9038b18c485fe7e71feb89d2e05602dfecad0cb6f2246fae096d4da425cca6e8a71056f28abd97ad98cf770a2018853248
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.0.0":
+"uuid@npm:^8.3.2":
   version: 8.3.2
   resolution: "uuid@npm:8.3.2"
   bin:
     uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  checksum: aed2bcef341f95635f308fea8831fb9038b18c485fe7e71feb89d2e05602dfecad0cb6f2246fae096d4da425cca6e8a71056f28abd97ad98cf770a2018853248
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
 Upgrade your UUID package version to >= 7 . Current Dependency of UUID package 3.3.2 is deprecated.

Contributing force only to use uuid 8.3.2