### PR TITLE
Don't delete from input rules object, fixes #1341

### DIFF
--- a/packages/graphql-shield/src/generator.ts
+++ b/packages/graphql-shield/src/generator.ts
@@ -139,10 +139,10 @@ function applyRuleToType(
 
     /* Extract default type wildcard if any and remove it for validation */
     const defaultTypeRule = rules['*']
-    delete rules['*']
+    const { '*': _, ...rulesWithoutWildcard } = rules
     /* Validation */
 
-    const fieldErrors = Object.keys(rules)
+    const fieldErrors = Object.keys(rulesWithoutWildcard)
       .filter((type) => !Object.prototype.hasOwnProperty.call(fieldMap, type))
       .map((field) => `${type.name}.${field}`)
       .join(', ')


### PR DESCRIPTION
Instead of deleting from the input permissions object, create a new object without the wildcard rule. This allows the permissions object to be re-used multiple times, eg. in tests.

