### PR TITLE
fix wildcard rules are not reusable

### DIFF
--- a/packages/graphql-shield/src/generator.ts
+++ b/packages/graphql-shield/src/generator.ts
@@ -139,10 +139,10 @@ function applyRuleToType(
 
     /* Extract default type wildcard if any and remove it for validation */
     const defaultTypeRule = rules['*']
-    delete rules['*']
+    const {'*': _, ...rulesWithoutWildcard} = rules;
     /* Validation */
 
-    const fieldErrors = Object.keys(rules)
+    const fieldErrors = Object.keys(rulesWithoutWildcard)
       .filter((type) => !Object.prototype.hasOwnProperty.call(fieldMap, type))
       .map((field) => `${type.name}.${field}`)
       .join(', ')


### PR DESCRIPTION
### Summary:

Fixes #1358 
Fixes #1341 
(slightly different problems with the same root cause)

When using wildcard rules, it was not possible to reuse the same object that had the `'*'` key defined in it.

### Cause:

Line 142: `delete rules['*']` was modifying the argument to the function (which is sort of an anti-pattern for this kind of reason) and was causing subsequent uses of the same object to not have the wildcard rule for their own usage.

The issue that I was facing was that if you attempt to apply the middleware to a schema two or more times, it only has the wildcard rules for the first invocation. I've determined that the line above is the root cause of both issues. 

### Testing:

I have added a test (a copy of the wildcard test, but with a double usage to cause the error to occur). It was correctly failing prior to the fix, and began passing after the fix was added.
