### PR TITLE
fix: expose ShieldRule and IOptionsConstructor

### DIFF
--- a/packages/graphql-shield/src/index.ts
+++ b/packages/graphql-shield/src/index.ts
@@ -1,4 +1,4 @@
-export { IRules, IRule } from './types.js'
+export { IRules, IRule, ShieldRule, IOptionsConstructor } from './types.js'
 export { shield } from './shield.js'
 export {
   rule,


### PR DESCRIPTION
I required the typings while creating a type safe pothos plugin for graphql-shield.