### PR TITLE
Fix: Small typo: "sentantce" to "sentence"

### DIFF
--- a/website/src/pages/docs/rules.mdx
+++ b/website/src/pages/docs/rules.mdx
@@ -2,7 +2,7 @@ import { Callout } from '@theguild/components'
 
 # Rules
 
-Rules let you define reusable blocks of permissions that you use in [Shield](./shield). GraphQL Shield packs a collection of general rules that make your permissions easier to write and your rules more reusable. Each rule you create should be easily explicable in one sentantce and should check exactly one permission.
+Rules let you define reusable blocks of permissions that you use in [Shield](./shield). GraphQL Shield packs a collection of general rules that make your permissions easier to write and your rules more reusable. Each rule you create should be easily explicable in one sentence and should check exactly one permission.
 
 For example, it's a good practice to have a rule that checks if someone is an admin and another one that checks if someone owns some data, and a bad practice to have both checks in one rule.
 


### PR DESCRIPTION
Fixes a small typo in the docs.