### PR TITLE
Added runAuthAfterResolver option to change execution order of authorization rules and resolvers.

### DIFF
--- a/packages/graphql-shield/src/generator.ts
+++ b/packages/graphql-shield/src/generator.ts
@@ -64,10 +64,20 @@ function generateFieldMiddlewareFromRule(
 
     // Execution
     try {
-      const res = await rule.resolve(parent, args, ctx, info, options)
-
+      let res
+      
+      if (!options.runAuthAfterResolver) {
+        res = await rule.resolve(parent, args, ctx, info, options)
+      }
+      
+      const resolverResult = await resolve(parent, args, ctx, info)
+      
+      if (options.runAuthAfterResolver) {
+        res = await rule.resolve(parent, args, ctx, info, options)
+      }
+      
       if (res === true) {
-        return await resolve(parent, args, ctx, info)
+        return resolverResult
       } else if (res === false) {
         if (typeof options.fallbackError === 'function') {
           return await options.fallbackError(null, parent, args, ctx, info)

--- a/packages/graphql-shield/src/types.ts
+++ b/packages/graphql-shield/src/types.ts
@@ -67,6 +67,7 @@ export type IFallbackErrorType = Error | IFallbackErrorMapperType
 // Generator Options
 
 export interface IOptions {
+  runAuthAfterResolver: boolean
   debug: boolean
   allowExternalErrors: boolean
   fallbackRule: ShieldRule


### PR DESCRIPTION
A new runAuthAfterResolver boolean field was added to the IOptions interface to allow configuring this option.

The generateFieldMiddlewareFromRule function was updated to check the runAuthAfterResolver option and call the rule's resolve method either before or after the main GraphQL resolver, depending on the value.

- If runAuthAfterResolver is true, it will call the rule's resolve after running the main resolver function.
- If false or unspecified, it maintains the existing behavior of calling the rule resolve first.
- This allows customizing whether the authorization rule logic runs before or after the main resolver execution.

Some reasons this change may have been made:
- To avoid running expensive authorization logic unnecessarily if the resolver itself fails.
- It allows the authorization logic to be influenced by or even directly use the outcome of the resolver. This is useful for situations where the decision on authorization depends on the result of the resolver or how the resolver execution concludes.

Overall this change provides more control over the timing and ordering of the authorization rules vs the resolvers when generating Auth Rules.